### PR TITLE
Fix sulfuric stromatolites not generating in existing saves

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,0 +1,10 @@
+script.on_init(function()
+  local vulcanus = game.surfaces.vulcanus
+  if vulcanus then
+    local mgs = vulcanus.map_gen_settings
+    if not mgs.autoplace_settings.entity.settings["sulfuric-stromatolite"] then
+      mgs.autoplace_settings.entity.settings["sulfuric-stromatolite"] = {}
+      vulcanus.map_gen_settings = mgs
+    end
+  end
+end)


### PR DESCRIPTION
Since the game can't know whether a value is missing from autoplace settings due to it being disabled or being added by a mod later, mods must manually populate things they want to be generated on existing saves via `on_init`, which is called when a new game is created *or* the mod is added to an existing game.

According to the example at https://lua-api.factorio.com/latest/concepts/MapGenSettings.html, the game gives you a copy of the MapGenSettings so you must write it back after changing values.